### PR TITLE
Pixeebot Security Findings - Introduced protections against predictable RNG abuse, Switch order of literals to prevent NullPointerException

### DIFF
--- a/app/src/main/java/org/mokee/warpshare/ReceiverService.java
+++ b/app/src/main/java/org/mokee/warpshare/ReceiverService.java
@@ -476,7 +476,7 @@ public class ReceiverService extends Service implements AirDropManager.ReceiverL
             if (segments.length != 2) continue;
             final String type = segments[0];
             final String subtype = segments[1];
-            if (type.equals("*") && !subtype.equals("*")) continue;
+            if ("*".equals(type) && !"*".equals(subtype)) continue;
 
             if (generalType == null) {
                 generalType = type;

--- a/app/src/main/java/org/mokee/warpshare/airdrop/AirDropConfigManager.java
+++ b/app/src/main/java/org/mokee/warpshare/airdrop/AirDropConfigManager.java
@@ -22,6 +22,7 @@ import android.content.SharedPreferences;
 import android.util.Log;
 
 import androidx.preference.PreferenceManager;
+import java.security.SecureRandom;
 
 import org.mokee.warpshare.ConfigManager;
 
@@ -51,7 +52,7 @@ class AirDropConfigManager {
 
     private String generateId() {
         byte[] id = new byte[6];
-        new Random().nextBytes(id);
+        new SecureRandom().nextBytes(id);
         return ByteString.of(id).hex();
     }
 


### PR DESCRIPTION
## Introduced protections against predictable RNG abuse
This change replaces all new instances of `java.util.Random` with the marginally slower, but much more secure `java.security.SecureRandom`.

We have to work pretty hard to get computers to generate genuinely unguessable random bits. The `java.util.Random` type uses a method of pseudo-random number generation that unfortunately emits fairly predictable numbers.

If the numbers it emits are predictable, then it's obviously not safe to use in cryptographic operations, file name creation, token construction, password generation, and anything else that's related to security. In fact, it may affect security even if it's not directly obvious.

Switching to a more secure version is simple and our changes all look something like this:

```diff
- Random r = new Random();
+ Random r = new java.security.SecureRandom();
```

<details>
  <summary>More reading</summary>

  * [https://owasp.org/www-community/vulnerabilities/Insecure_Randomness](https://owasp.org/www-community/vulnerabilities/Insecure_Randomness)
  * [https://metebalci.com/blog/everything-about-javas-securerandom/](https://metebalci.com/blog/everything-about-javas-securerandom/)
  * [https://cwe.mitre.org/data/definitions/330.html](https://cwe.mitre.org/data/definitions/330.html)
</details>

## Switch order of literals to prevent NullPointerException

This change defensively switches the order of literals in comparison expressions to ensure that no null pointer exceptions are unexpectedly thrown. Runtime exceptions especially can cause exceptional and unexpected code paths to be taken, and this can result in unexpected behavior. 

Both simple vulnerabilities (like information disclosure) and complex vulnerabilities (like business logic flaws) can take advantage of these unexpected code paths.

Our changes look something like this:

```diff
  String fieldName = header.getFieldName();
  String fieldValue = header.getFieldValue();
- if(fieldName.equals("requestId")) {
+ if("requestId".equals(fieldName)) {
    logRequest(fieldValue);
  }
```

<details>
  <summary>More reading</summary>

  * [http://cwe.mitre.org/data/definitions/476.html](http://cwe.mitre.org/data/definitions/476.html)
  * [https://en.wikibooks.org/wiki/Java_Programming/Preventing_NullPointerException](https://en.wikibooks.org/wiki/Java_Programming/Preventing_NullPointerException)
  * [https://rules.sonarsource.com/java/RSPEC-1132/](https://rules.sonarsource.com/java/RSPEC-1132/)
</details>

Powered by: [pixeebot](https://docs.pixee.ai/installing/) (codemod ID: [pixee:java/switch-literal-first](https://docs.pixee.ai/codemods/java/pixee_java_switch-literal-first)) ![](https://d1zaessa2hpsmj.cloudfront.net/pixel/v1/track?writeKey=2PI43jNm7atYvAuK7rJUz3Kcd6A&event=DRIP_PR%7CPixee-Bot-zc%2Fandroid_packages_apps_WarpShare%7Cfdf0ea4d535fc015775445bc5c0d3d76cca3cd90)

<!--{"type":"DRIP","codemod":"pixee:java/switch-literal-first"}-->